### PR TITLE
Fix registration error message

### DIFF
--- a/src/components/RegisterModal.tsx
+++ b/src/components/RegisterModal.tsx
@@ -69,12 +69,16 @@ const RegisterModal = ({ isOpen, onClose, onSwitchToSignIn }: RegisterModalProps
       return;
     }
     
-    const success = await register(username, email, password);
+    const { success, error: registerError } = await register(
+      username,
+      email,
+      password
+    );
     if (success) {
       console.log('Registration successful');
       handleClose();
     } else {
-      setError('User with this email already exists');
+      setError(registerError || 'Registration failed');
     }
   };
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -10,7 +10,11 @@ interface User {
 interface AuthContextType {
   user: User | null;
   login: (email: string, password: string) => Promise<boolean>;
-  register: (username: string, email: string, password: string) => Promise<boolean>;
+  register: (
+    username: string,
+    email: string,
+    password: string
+  ) => Promise<{ success: boolean; error?: string }>;
   logout: () => Promise<void>;
   isAuthenticated: boolean;
 }
@@ -80,7 +84,11 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     return true;
   };
 
-  const register = async (username: string, email: string, password: string): Promise<boolean> => {
+  const register = async (
+    username: string,
+    email: string,
+    password: string
+  ): Promise<{ success: boolean; error?: string }> => {
     const { data, error } = await supabase.auth.signUp({
       email,
       password,
@@ -89,13 +97,13 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       }
     });
     if (error || !data.user) {
-      return false;
+      return { success: false, error: error?.message };
     }
     setUser({
       email: data.user.email || '',
       username
     });
-    return true;
+    return { success: true };
   };
 
   const logout = async () => {


### PR DESCRIPTION
## Summary
- adjust `AuthContext.register` to return error details
- display Supabase signup errors in `RegisterModal`

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run build:dev`

------
https://chatgpt.com/codex/tasks/task_e_684a01b032b88325a3a40bad819bb695