### PR TITLE
Improve login error handling

### DIFF
--- a/src/components/SignInModal.tsx
+++ b/src/components/SignInModal.tsx
@@ -59,12 +59,12 @@ const SignInModal = ({ isOpen, onClose, onSwitchToRegister }: SignInModalProps) 
     e.preventDefault();
     setError('');
 
-    const success = await login(email, password);
+    const { success, error: loginError } = await login(email, password);
     if (success) {
       console.log('Sign in successful');
       handleClose();
     } else {
-      setError('Invalid email or password');
+      setError(loginError || 'Invalid email or password');
     }
   };
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -15,7 +15,10 @@ interface User {
 
 interface AuthContextType {
   user: User | null;
-  login: (email: string, password: string) => Promise<boolean>;
+  login: (
+    email: string,
+    password: string,
+  ) => Promise<{ success: boolean; error?: string }>;
   register: (
     username: string,
     email: string,
@@ -77,20 +80,23 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     };
   }, []);
 
-  const login = async (email: string, password: string): Promise<boolean> => {
+  const login = async (
+    email: string,
+    password: string,
+  ): Promise<{ success: boolean; error?: string }> => {
     const { data, error } = await supabase.auth.signInWithPassword({
       email,
       password,
     });
     if (error || !data.user) {
-      return false;
+      return { success: false, error: error?.message };
     }
     setUser({
       id: data.user.id,
       email: data.user.email || "",
       username: (data.user.user_metadata as any)?.username || "",
     });
-    return true;
+    return { success: true };
   };
 
   const register = async (


### PR DESCRIPTION
## Summary
- make AuthContext.login return supabase error messages
- surface Supabase errors in SignInModal

## Testing
- `npm run lint` *(fails: several lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684a063188b48325a3f86ee9899a5ecb